### PR TITLE
Fix horizontal off-by-one binary image rendering

### DIFF
--- a/.github/workflows/inventory_updater/lib/inventory_updater/analogue/binary_image.rb
+++ b/.github/workflows/inventory_updater/lib/inventory_updater/analogue/binary_image.rb
@@ -7,7 +7,7 @@ class BinaryImage
     image = ChunkyPNG::Image.new(width, height)
 
     index = 0
-    x = width - 1
+    x = width
 
     while x >= 0
       y = 0


### PR DESCRIPTION
- My original take on this was off by one as well https://github.com/neil-morrison44/pocket-sync/pull/55/files , no idea why it made sense to subtract one from the width at some point but this should fix it