### PR TITLE
link to v2 api documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ bundle exec jekyll serve
 Then navigate to `http://localhost:4000/`
 
 ## Cores API
-openFPGA Cores Inventory provides a read-only API for developers. More information can be found in the [documentation](_docs/v1.md).
+openFPGA Cores Inventory provides a read-only API for developers. More information can be found in the [documentation](_docs/v2.md).
 
 ## Adding a new core
 To add a new core, you will need to edit the `_data/repos.yml` file. You must add the following fields:


### PR DESCRIPTION
the readme is still pointing to the v1 documentation