### PR TITLE
fix: specify assets for Spiritualized.SuperGB core

### DIFF
--- a/_data/cores.yml
+++ b/_data/cores.yml
@@ -3842,6 +3842,16 @@
       - gb
       - gbc
       - bin
+    - platform: sgb
+      filename: sgb_boot.bin
+      extensions:
+      - bin
+      core_specific: true
+    - platform: sgb
+      filename: sgb_snes.smc
+      extensions:
+      - smc
+      core_specific: true
   - id: Spiritualized.Supervision
     display_name: Spiritualized Supervision
     repository:


### PR DESCRIPTION
`sgb_boot.bin` and `sgb_snes.smc` are needed for the core to be used