### PR TITLE
fix d/l-URL and tag for "RndMnkIII.alphamission_Analogizer"

### DIFF
--- a/_data/cores.yml
+++ b/_data/cores.yml
@@ -3204,7 +3204,7 @@
       platform: github
       name: Analogizer-Pocket-Alpha-Mission
       prerelease: false
-      tag_name: '1.1'
+      tag_name: 'Analogizer_V1.1'
     requires_license: false
     download_url: https://github.com/RndMnkIII/Analogizer-Pocket-Alpha-Mission/releases/download/Analogizer_V1.1/analogizer-alphamission-pocket-v1.1.zip
     platform_id: alphamission

--- a/_data/cores.yml
+++ b/_data/cores.yml
@@ -3204,12 +3204,12 @@
       platform: github
       name: Analogizer-Pocket-Alpha-Mission
       prerelease: false
-      tag_name: 'Analogizer_V1.1'
+      tag_name: '1.0'
     requires_license: false
-    download_url: https://github.com/RndMnkIII/Analogizer-Pocket-Alpha-Mission/releases/download/Analogizer_V1.1/analogizer-alphamission-pocket-v1.1.zip
+    download_url: https://github.com/RndMnkIII/Analogizer-Pocket-Alpha-Mission/releases/download/1.0/PocketAlphaMission_Analogizer_build.zip
     platform_id: alphamission
     description: "[ANALOGIZER] SNK Alpha Mission gateware IP Core"
-    version: '1.1'
+    version: 1.0
     date_release: '2024-03-24'
     platform:
       category: Arcade

--- a/_data/cores.yml
+++ b/_data/cores.yml
@@ -3204,9 +3204,9 @@
       platform: github
       name: Analogizer-Pocket-Alpha-Mission
       prerelease: false
-      tag_name: '1.0'
+      tag_name: '1.1'
     requires_license: false
-    download_url: https://github.com/RndMnkIII/Analogizer-Pocket-Alpha-Mission/releases/download/1.0/PocketAlphaMission_Analogizer_build.zip
+    download_url: https://github.com/RndMnkIII/Analogizer-Pocket-Alpha-Mission/releases/download/Analogizer_V1.1/analogizer-alphamission-pocket-v1.1.zip
     platform_id: alphamission
     description: "[ANALOGIZER] SNK Alpha Mission gateware IP Core"
     version: '1.1'


### PR DESCRIPTION
Hi there,

the download-URL for the "RndMnkIII.alphamission_Analogizer" core is invalid and returns a `404`.

I fixed the URL and updated the corresponding `tag_name`.

Thanks.