### PR TITLE
Update sources.yml

### DIFF
--- a/_data/sources.yml
+++ b/_data/sources.yml
@@ -242,6 +242,10 @@
 - repository: timboettiger/openfpga-snes-pro-action-replay-mk3
 - repository: openfpgaos/diablo
 - repository: drizzt/openfpga-sms
+  assets:
+    - openfpga-SMS_.*\.zip
+    - openfpga-GG_.*\.zip
+    - openfpga-SG-1000_.*\.zip
 - repository: opengateware/arcade-deco32
   assets:
     - opengateware.deco32(.*)-pocket.zip


### PR DESCRIPTION
drizzt/openfpga-SMS now publishes one zip per platform (`openfpga-SMS_*.zip`, `openfpga-GG_*.zip`, `openfpga-SG-1000_*.zip`) instead of a single combined zip, so installing one core no longer drops all three on the SD card.

Add an `assets:` regex per platform so each core (Master System / Game Gear / SG-1000) maps to its own single-core zip. Without it the updater records only the first matching zip and all three cores share one combined `download_url`.

Per-platform zips ship from v1.2.1 onward; the patterns also match the older combined zips harmlessly (older releases stay in each core's history, latest wins).