### PR TITLE
Removes moved `thinkelastic/*` repos from sources.yml

### DIFF
--- a/_data/sources.yml
+++ b/_data/sources.yml
@@ -233,8 +233,6 @@
 - repository: obsidian-dot-dev/pockettyrian
 - repository: rndmnkiii/modplayer_openfpgaos
 - repository: obsidian-dot-dev/openfpga-spaceinvaders
-- repository: thinkelastic/duke3d
-- repository: thinkelastic/doom
 - repository: openfpgaos/quake
 - repository: openfpgaos/doom
 - repository: openfpgaos/duke3d


### PR DESCRIPTION
Was wondering why Pocket Sync wasn't pulling in GitHub info for these cores, they've both been moved (https://github.com/thinkelastic/Doom & https://github.com/thinkelastic/Duke3D)

Feel free to treat this as an issue instead of a PR if this isn't the solution, this file was the only result I got for `thinkelastic/Doom` that just felt slightly autogenerated instead of very autogenerated.

If both need kept for data consistency reasons (since the core used to be there) then swapping the order of them will probably get the output JSON listing the active GitHub link (can see the DOOM core here also linking to the old repo https://openfpga-library.github.io/analogue-pocket/)