### PR TITLE
fix: process every matching release asset per run

### DIFF
--- a/.github/workflows/updater/lib/updater.rb
+++ b/.github/workflows/updater/lib/updater.rb
@@ -69,7 +69,7 @@ class Updater < Thor
           next if asset.nil?
 
           @logger.info("Processing asset: #{asset.name}")
-          new_release ||= update_source(repository, funding, asset.created_at, asset.browser_download_url)
+          new_release = update_source(repository, funding, asset.created_at, asset.browser_download_url) || new_release
         end
 
         break unless new_release


### PR DESCRIPTION
## Problem

The release-asset loop in `update_inventory` assigned with:

```ruby
new_release ||= update_source(repository, funding, asset.created_at, asset.browser_download_url)
```

`||=` short-circuits: once any asset in a release returns `true`, `update_source` is not called for the remaining matching assets. When a single GitHub release ships **multiple core zips** — e.g. `drizzt/openfpga-sms` bundles `openfpga-SMS_*.zip`, `openfpga-GG_*.zip` and `openfpga-SG-1000_*.zip`, all matched by that source's `assets:` patterns — only the first *new* asset is ingested per run. The siblings then advance one-per-subsequent-scheduled-run instead of together, so an inventory can sit with SMS at 1.2.2 while GG/SG-1000 lag at 1.2.1 for several cron cycles.

## Fix

```ruby
new_release = update_source(repository, funding, asset.created_at, asset.browser_download_url) || new_release
```

`update_source` now runs for every matching asset in the release. The final value of `new_release` is identical to before (true iff any asset was new), so the outer `break unless new_release` behavior is unchanged. `add_release` still dedups by `download_url`, so re-runs remain idempotent.

## Verification

Ran the real `update-inventory` CLI against an isolated copy with sources trimmed to `drizzt/openfpga-sms`:

- **Before (`||=`):** one run advances a single core (GG → 1.2.2, SG-1000 stays 1.2.1); a second run is needed for SG-1000.
- **After (`|| new_release`):** one run advances **both** GG and SG-1000 to 1.2.2.
- Re-run is idempotent — no duplicate release entries.