### PR TITLE
Remove assets block from HarpMudd.tapper core

### DIFF
--- a/_data/sources.yml
+++ b/_data/sources.yml
@@ -247,5 +247,3 @@
     - opengateware.deco32(.*)-pocket.zip
 - repository: thediscordian/openfpga-pacman
 - repository: harpmudd/harpmudd.tapper
-  assets:
-    - HarpMudd.tapper_


### PR DESCRIPTION
I think this assets block is causing some issues with updaters https://github.com/neil-morrison44/pocket-sync/issues/457