### PR TITLE
Add BrickBoy DMG core source

### DIFF
--- a/_data/sources.yml
+++ b/_data/sources.yml
@@ -153,6 +153,7 @@
     - pocket/zips/jotego.jtgae1.zip
     - pocket/zips/jotego.jtgals.zip
     - pocket/zips/jotego.jtpktgal.zip
+- repository: kathoc/brickboy-dmg-fpgacore
 - repository: markus-zzz/myc64-pocket
 - repository: mazamars312/analogue-amiga
 - repository: mazamars312/analogue_pocket_neogeo


### PR DESCRIPTION
BrickBoy DMG (https://github.com/kathoc/brickboy-dmg-fpgacore) was been released very recently and I love it, it is by far the most accurate experience for DMG. 

it would be great to include it upstream

more info https://www.timeextension.com/news/2026/08/the-most-gorgeous-game-boy-emulation-ive-ever-seen-brick-boy-goes-the-extra-mile-to-copy-the-consoles-nostalgic-display

cheers