### PR TITLE
add Picocomputer 6502

### DIFF
--- a/_data/sources.yml
+++ b/_data/sources.yml
@@ -294,3 +294,6 @@
   assets:
     - finn2k1.RallyBike_
 - repository: nlhomme/arcade-bosconian_analogue-pocket
+- repository: picocomputer/rp6502
+  assets:
+    - rp6502-.*-pocket\.zip


### PR DESCRIPTION
I didn't have any luck doing a dry run. The README references a file I can't find `_data/repos.yml`. So I'm guessing this is the necessary change.